### PR TITLE
Fix translation of "salted".

### DIFF
--- a/reference/datamodel.po
+++ b/reference/datamodel.po
@@ -2062,7 +2062,7 @@ msgid ""
 "constant within an individual Python process, they are not predictable "
 "between repeated invocations of Python."
 msgstr ""
-"デフォルトでは、文字列、バイト列、datetime オブジェクトの :meth:`__hash__` 値は予測不可能なランダム値で \"塩漬け\" "
+"デフォルトでは、文字列、バイト列、datetime オブジェクトの :meth:`__hash__` 値は予測不可能なランダム値で \"ソルト\" "
 "されます。 ハッシュ値は単独の Python プロセス内では定数であり続けますが、Python を繰り返し起動する毎に、予測できなくなります。"
 
 #: ../../reference/datamodel.rst:1448

--- a/using/cmdline.po
+++ b/using/cmdline.po
@@ -435,7 +435,7 @@ msgid ""
 "invocations of Python."
 msgstr ""
 "以前のバージョンの Python では、このオプションはハッシュのランダム化を有効にします。これにより、 str, bytes, datetime 型の"
-" :meth:`__hash__` 値が予測不可能な乱数で \"塩漬け\" されます。ハッシュ値は各 Python プロセスでは固定ですが、 "
+" :meth:`__hash__` 値が予測不可能な乱数で \"ソルト\" されます。ハッシュ値は各 Python プロセスでは固定ですが、 "
 "Python を繰り返し再実行した場合は別の予測不能な値になります。"
 
 #: ../../using/cmdline.rst:305


### PR DESCRIPTION
- Should be "ソルト", not "塩漬け".
- Close: #8