### PR TITLE
update.sh: tx-push before changing the tx config

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -25,6 +25,11 @@ cd  locales
 sphinx-intl create-txconfig
 sphinx-intl update-txconfig-resources -p pot -d . --transifex-project-name python-newest
 
+if [ "$CI" = true ]
+then
+    tx push --source --no-interactive --skip
+fi
+
 # Update the translation project's .tx/config
 cd ../../..     # back to $ROOTDIR
 mkdir -p .tx
@@ -33,9 +38,5 @@ sed cpython/Doc/locales/.tx/config \
   -e 's|<lang>/LC_MESSAGES/||' \
   -e "s|^file_filter|trans.${LANGUAGE}|" \
   > .tx/config
-  
-if [ "$CI" = true ]
-then
-    tx push --source --no-interactive --skip
-fi
+
 tx pull -l ${LANGUAGE} --use-git-timestamps --parallel


### PR DESCRIPTION
This PR should hopefully fix running `tx push` by running it before preparing for the `tx pull`. See bugged workflow run: https://github.com/python/python-docs-ja/runs/6283854245?check_suite_focus=true