### PR TITLE
Temporary use actions/checkout@v1 to avoid checkout error

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -79,10 +79,9 @@ jobs:
         run:
           echo "CURRENT_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
       - name: Check out source branch (${{ env.CURRENT_BRANCH }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           path: ${{ env.CURRENT_BRANCH }}
-          persist-credentials: false
       - name: Check out target branch (${{ matrix.branch }})
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Github action  actions/checkout@v2 causes an error in the link follow.

https://github.com/python/python-docs-ja/runs/6913633817?check_suite_focus=true

Using actions/checkout@v1 for workaround.

related issue: https://github.com/actions/checkout/issues/610
