### PR TITLE
Improve ci

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           powrap --modified -C ${{ matrix.branch }}
       - name: Commit and push changes
-        if: github.repository == 'rffontenelle/python-docs-pt-br'
+        if: github.repository == 'python/python-docs-ja'
         run: |
           cd ${{ matrix.branch }}
           git config user.name github-actions

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Transifex CLI
         run: |
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
-          mv tx /usr/local/bin/tx
+        working-directory: /usr/local/bin
       - name: Install dependencies
         run: |
           sudo apt update -y && sudo apt install gettext -y

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,18 +23,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check out CPython
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: python/cpython
           persist-credentials: false
           ref: ${{ env.CPYTHON_BRANCH }}
           path: cpython
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install Transifex CLI
         run: |
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
@@ -83,14 +85,20 @@ jobs:
         run:
           echo "CURRENT_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
       - name: Check out source branch (${{ env.CURRENT_BRANCH }})
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           path: ${{ env.CURRENT_BRANCH }}
       - name: Check out target branch (${{ matrix.branch }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}
           path: ${{ matrix.branch }}
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+          cache-dependency-path: '**/requirements*.txt'
       - name: Install dependencies
         run: |
           sudo apt update -y && sudo apt install gettext -y

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.9'
+      - name: Install Transifex CLI
+        run: |
+          curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+          mv tx /usr/local/bin/tx
       - name: Install dependencies
         run: |
           sudo apt update -y && sudo apt install gettext -y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-transifex-client
 sphinx
 sphinx-intl
 powrap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
-sphinx-intl
+git+https://github.com/sphinx-doc/sphinx-intl@6b3913fea5a8c9b819818b9b28b6d0d0b6f022b3
 powrap
 pospell
 pomerge

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -25,12 +25,8 @@ cd locales
 sphinx-intl create-txconfig
 sphinx-intl update-txconfig-resources -p pot -d . --transifex-organization-name python-doc --transifex-project-name python-newest
 
-if [ "$CI" = true ]; then
-    tx push --source --no-interactive --skip
-fi
-
 # Pull translations into cpython/Doc/locales/LANGUAGE/LC_MESSAGES/
-tx pull -l ${LANGUAGE} -t --use-git-timestamps -f
+tx pull -l ${LANGUAGE} -t --use-git-timestamps
 
 # Finally, move downloaded translation files to the language's repository
 cd "${LANGUAGE}/LC_MESSAGES/"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -7,9 +7,9 @@ set -e
 # Allow language being passed as 1st argument, defaults to ja
 LANGUAGE=${1:-ja}
 
-ROOTDIR=$(dirname $0)/..
+ROOTDIR=$(realpath "$(dirname $0)/..")
 
-cd ${ROOTDIR}
+cd "${ROOTDIR}"
 
 if ! test -f cpython/Doc/conf.py; then
   echo Unable to find proper CPython Doc folder
@@ -21,22 +21,19 @@ cd cpython/Doc
 sphinx-build -E -b gettext -D gettext_compact=0 -d build/.doctrees . locales/pot
 
 # Update CPython's .tx/config
-cd  locales
+cd locales
 sphinx-intl create-txconfig
-sphinx-intl update-txconfig-resources -p pot -d . --transifex-project-name python-newest
+sphinx-intl update-txconfig-resources -p pot -d . --transifex-organization-name python-doc --transifex-project-name python-newest
 
-if [ "$CI" = true ]
-then
+if [ "$CI" = true ]; then
     tx push --source --no-interactive --skip
 fi
 
-# Update the translation project's .tx/config
-cd ../../..     # back to $ROOTDIR
-mkdir -p .tx
-sed cpython/Doc/locales/.tx/config \
-  -e '/^source_file/d' \
-  -e 's|<lang>/LC_MESSAGES/||' \
-  -e "s|^file_filter|trans.${LANGUAGE}|" \
-  > .tx/config
+# Pull translations into cpython/Doc/locales/LANGUAGE/LC_MESSAGES/
+tx pull -l ${LANGUAGE} -t --use-git-timestamps -f
 
-tx pull -l ${LANGUAGE} --use-git-timestamps --parallel
+# Finally, move downloaded translation files to the language's repository
+cd "${LANGUAGE}/LC_MESSAGES/"
+for po in $(find . -type f -name '*.po' | sort | sed 's|^\./||'); do
+  install -Dm644 ${po} "${ROOTDIR}/${po}"
+done


### PR DESCRIPTION
- **Use the new Transifex CLI  toll:** The Python implementation named transifex-client uses Transifex's APIv2, which is deprecated and will sunset in november 2022. The new tool, called Transifex CLI, is written in Golang and is APIv3-ready. So adjusting the CI and requirements.txt is required.
- **Fix condition in the merge job]:** Having the proper condition is important to have the translation
update in the latest Python version (python-newest project), and
the condition wouldn't match the current repository.