### PR TITLE
ci(lint-and-built): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/lint-and-built.yml
+++ b/.github/workflows/lint-and-built.yml
@@ -10,6 +10,9 @@ on:
       - '*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-translation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.